### PR TITLE
Updated python script.

### DIFF
--- a/combineJournalLists.py
+++ b/combineJournalLists.py
@@ -12,14 +12,17 @@ import os
 
 outFile = sys.argv[1]
 dictionary = dict()
+
 for i in range(2,len(sys.argv)):
     count = 0
     f = open(sys.argv[i], "r")
     for line in f:
-	if line[0] != "#":
-	    count = count+1
-	    parts = line.partition("=")
-	    dictionary[parts[0].strip()] = line.strip()
+        if "=" in line:
+            if all(ord(ch) < 128 for ch in line):
+                if line[0] != "#":
+                    count = count+1
+                    parts = line.partition("=")
+                    dictionary[parts[0].strip()] = line.strip()
     f.close()
     print sys.argv[i]+": "+str(count)
 
@@ -27,5 +30,5 @@ print "Combined key count: "+str(len(dictionary))
 
 f = open(outFile, "w")
 for key in sorted(dictionary.iterkeys()):
-      f.write(dictionary[key]+"\n")
+    f.write(dictionary[key]+"\n")
 f.close()

--- a/combineJournalLists.py
+++ b/combineJournalLists.py
@@ -18,7 +18,6 @@ for i in range(2,len(sys.argv)):
     f = open(sys.argv[i], "r")
     for line in f:
         if "=" in line:
-            if all(ord(ch) < 128 for ch in line):
                 if line[0] != "#":
                     count = count+1
                     parts = line.partition("=")


### PR DESCRIPTION
Journal abbreviations files contain non ascii characters and some journals do not have abbreviations. Instead of fixing those journal names and abbreviations, I simply remove them.

Signed-off-by: Emrah Er <eer@eremrah.com>